### PR TITLE
Output point cloud to las

### DIFF
--- a/simulocloud/pointcloud.py
+++ b/simulocloud/pointcloud.py
@@ -133,6 +133,17 @@ class PointCloud(object):
         
         return PointCloud(self.points[~out_of_bounds])
 
+    def to_txt(self, fpath):
+        """Export point cloud coordinates as 3-column (xyz) ASCII file.
+    
+        Arguments
+        ---------
+        fpath: str
+            path to file to write 
+        
+        """
+        np.savetxt(fpath, self.arr.T)
+
 
 # Container for bounds box surrounding PointCloud
 Bounds = namedtuple('Bounds', ['minx', 'miny', 'minz', 'maxx', 'maxy', 'maxz'])

--- a/simulocloud/pointcloud.py
+++ b/simulocloud/pointcloud.py
@@ -5,13 +5,14 @@ Read in and store point clouds.
 """
 
 import numpy as np
-import laspy
+from laspy.file import File
+from laspy.header import Header, VLR
 from collections import namedtuple
 from .exceptions import EmptyPointCloud
 
 class PointCloud(object):
     """ Contains point cloud data """
-
+    
     dtype = np.float64
 
     def __init__(self, xyz):
@@ -49,18 +50,18 @@ class PointCloud(object):
         return len(self.points)
     
     """ Constructor methods """
-    
+ 
     @classmethod
     def from_las(cls, fpath):
         """Initialise PointCloud from .las file.
-
+    
         Arguments
         ---------
         fpath: str
             filepath of .las file containing 3D point coordinates
        
         """
-        with laspy.file.File(fpath) as f:
+        with File(fpath) as f:
             return cls.from_laspy_File(f)
 
     @classmethod
@@ -76,7 +77,7 @@ class PointCloud(object):
         return PointCloud((f.x, f.y, f.z))
     
     """ Instance methods """
-    
+
     @property
     def arr(self):
         """Get point coordinates as unstructured n*3 array).
@@ -84,7 +85,7 @@ class PointCloud(object):
         Returns
         -------
         np.ndarray with shape (npoints, 3)
-
+    
         """
         return self.points.view(self.dtype).reshape(-1, 3)
 
@@ -95,7 +96,7 @@ class PointCloud(object):
         Returns
         -------
         namedtuple (minx, miny, minz, maxx, maxy, maxz)
-
+        
         """
         p = self.points
         return Bounds(np.min(p['x']), np.min(p['y']), np.min(p['z']),
@@ -116,7 +117,7 @@ class PointCloud(object):
         -------
         PointCloud instance
             new object containing only points within specified bounds
-
+        
         """
         # Build results using generator to limit memory usage
         out_of_bounds = np.zeros(len(self))
@@ -130,7 +131,7 @@ class PointCloud(object):
             else:
                 raise EmptyPointCloud, "No points in crop bounds:\n{}".format(
                                             bounds)
-        
+         
         return PointCloud(self.points[~out_of_bounds])
 
     def to_txt(self, fpath):

--- a/tests/test_pointcloud.py
+++ b/tests/test_pointcloud.py
@@ -126,3 +126,9 @@ def test_cropping_to_nothing_raises_exception_when_specified(pc, inf_bounds):
 def test_cropping_to_nothing_returns_empty(pc, inf_bounds):
     """Does PointCloud cropping return an empty PointCloud when asked?"""
     assert not len(pc.crop(inf_bounds, return_empty=True))
+
+def test_PointCloud_exports_transparently_to_txt(pc, tmpdir):
+    """Is the file output by PointCloud.to_txt identical to the input?"""
+    fpath = tmpdir.join("_INPUT_DATA.txt").strpath
+    pc.to_txt(fpath) 
+    assert np.all(pc.points == PointCloud(np.loadtxt(fpath)).points)

--- a/tests/test_pointcloud.py
+++ b/tests/test_pointcloud.py
@@ -139,3 +139,11 @@ def test_PointCloud_exports_transparently_to_txt(pc_arr, tmpdir):
     pc_arr.to_txt(fpath) 
 
     assert np.all(pc_arr.points == PointCloud(np.loadtxt(fpath)).points)
+
+
+def test_PointCloud_exports_transparently_to_las(pc_las, tmpdir):
+    """Are the points in the file output by PointCloud.to_las identical to input?"""
+    fpath = tmpdir.join('pc_las.las').strpath
+    pc_las.to_las(fpath)
+    
+    assert np.all(pc_las.points == PointCloud.from_las(fpath).points)

--- a/tests/test_pointcloud.py
+++ b/tests/test_pointcloud.py
@@ -45,6 +45,11 @@ def pc_arr(input_array):
     return PointCloud(input_array)
 
 @pytest.fixture
+def pc_las(fname='ALS.las'):
+    """Set up a PointCloud instance using test data"""
+    return PointCloud.from_las(abspath(fname))
+
+@pytest.fixture
 def none_bounds():
     """A Bounds nametuple with all bounds set to None."""
     return Bounds(*(None,)*6)
@@ -53,6 +58,7 @@ def none_bounds():
 def inf_bounds():
     """A Bounds namedtuple with all bounds set to inf/-inf."""
     return Bounds(*(np.inf,)*3 + (np.inf,)*3)
+
 """ Helper functions """
 
 def abspath(fname, fdir='data'):
@@ -61,13 +67,13 @@ def abspath(fname, fdir='data'):
 
 """ Test functions """
 
-def test_PointCloud_read_from_array(input_array, expected_DATA_points):
+def test_PointCloud_read_from_array(pc_arr, expected_DATA_points):
     """Can PointCloud initialise directly from a [xs, ys, zs] array?"""
-    assert np.all(PointCloud(input_array).points == expected_DATA_points)
+    assert np.all(pc_arr.points == expected_DATA_points)
 
-def test_PointCloud_read_from_las(expected_las_points, fname='ALS.las'):
+def test_PointCloud_read_from_las(pc_las, expected_las_points):
     """Can PointCloud be constructed from a .las file?"""
-    assert np.all(PointCloud.from_las(abspath(fname)).points == expected_las_points)
+    assert np.all(pc_las.points == expected_las_points)
 
 def test_arr_generation(pc_arr, input_array):
     """Does PointCloud.arr work as expected?."""
@@ -133,4 +139,3 @@ def test_PointCloud_exports_transparently_to_txt(pc_arr, tmpdir):
     pc_arr.to_txt(fpath) 
 
     assert np.all(pc_arr.points == PointCloud(np.loadtxt(fpath)).points)
-

--- a/tests/test_pointcloud.py
+++ b/tests/test_pointcloud.py
@@ -5,7 +5,7 @@ import numpy as np
 import cPickle as pkl
 import os
 
-""" Test data """
+""" Constants and fixtures """
 # Data type used for arrays
 _DTYPE = np.float64
 _INPUT_DATA = [[0.0, 0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8, 0.9],
@@ -14,7 +14,7 @@ _INPUT_DATA = [[0.0, 0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8, 0.9],
 
 @pytest.fixture
 def expected_DATA_points():
-    """The points array that should be generated from `input_list`."""
+    """The points array that should be generated from input_list."""
     return np.array([( 0. ,  1. ,  2. ),
                      ( 0.1,  1.1,  2.1),
                      ( 0.2,  1.2,  2.2),
@@ -29,7 +29,7 @@ def expected_DATA_points():
 
 @pytest.fixture
 def input_array():
-    """Simple [xs, ys, zs] numpy.ndarray of `input_list`."""
+    """Simple [xs, ys, zs] numpy.ndarray of input_list."""
     return np.array(_INPUT_DATA, dtype=_DTYPE)
 
 @pytest.fixture
@@ -41,7 +41,7 @@ def expected_las_points(fname='ALS_points.pkl'):
 
 @pytest.fixture
 def pc_arr(input_array):
-    """Set up a `PointCloud` instance using array test data."""
+    """Set up a PointCloud instance using array test data."""
     return PointCloud(input_array)
 
 @pytest.fixture
@@ -62,11 +62,11 @@ def abspath(fname, fdir='data'):
 """ Test functions """
 
 def test_PointCloud_read_from_array(input_array, expected_DATA_points):
-    """Can PointCloud initialise directly from a `[xs, ys, zs]` array?"""
+    """Can PointCloud initialise directly from a [xs, ys, zs] array?"""
     assert np.all(PointCloud(input_array).points == expected_DATA_points)
 
 def test_PointCloud_read_from_las(expected_las_points, fname='ALS.las'):
-    """Can PointCloud be constructed from a `.las` file?"""
+    """Can PointCloud be constructed from a .las file?"""
     assert np.all(PointCloud.from_las(abspath(fname)).points == expected_las_points)
 
 def test_arr_generation(pc_arr, input_array):
@@ -99,7 +99,7 @@ def test_cropping_is_lower_bounds_inclusive(pc_arr, none_bounds, c):
     
     # Apply lower bound cropping to a single dimension
     pc_cropped = pc_arr.crop(none_bounds._replace(**{'min'+c: minc}))
-
+    
     assert np.sort(pc_cropped.points, order=c)[0] == lowest_point
 
 @pytest.mark.parametrize('c', ('x', 'y', 'z'))
@@ -112,10 +112,9 @@ def test_cropping_is_upper_bounds_exclusive(pc_arr, none_bounds, c):
             oob_point = rev_sorted_points[i]
             highest_point = rev_sorted_points[i+1]
             break
-
     # Apply upper bound cropping to a single dimension
     pc_arr = pc_arr.crop(none_bounds._replace(**{'max'+c: maxc}))
-
+    
     assert (np.sort(pc_arr.points, order=c)[-1] == highest_point) and (
            oob_point not in pc_arr.points)
 
@@ -132,5 +131,6 @@ def test_PointCloud_exports_transparently_to_txt(pc_arr, tmpdir):
     """Is the file output by PointCloud.to_txt identical to the input?"""
     fpath = tmpdir.join("_INPUT_DATA.txt").strpath
     pc_arr.to_txt(fpath) 
+
     assert np.all(pc_arr.points == PointCloud(np.loadtxt(fpath)).points)
 


### PR DESCRIPTION
Implement the `to_las` method to write point cloud coordinates to a standard .las file complete with up-to-date header information.