### PR TITLE
Pointsectomy

### DIFF
--- a/simulocloud/pointcloud.py
+++ b/simulocloud/pointcloud.py
@@ -73,11 +73,11 @@ class PointCloud(object):
 
     def __len__(self):
         """Number of points in point cloud"""
-        return len(self.points)
+        return len(self.arr)
 
     def __add__(self, other):
         """Concatenate two PointClouds."""
-        return type(self)(np.concatenate([self.arr, other.arr]).T)
+        return type(self)(np.concatenate([self.arr, other.arr], axis=1))
 
     """ Constructor methods """
  
@@ -135,17 +135,17 @@ class PointCloud(object):
     @property
     def x(self):
         """The x dimension of point coordinates."""
-        return self.points['x']
+        return self.arr[0]
 
     @property
     def y(self):
         """The y dimension of point coordinates."""
-        return self.points['y']
+        return self.arr[1]
 
     @property
     def z(self):
         """The z dimension of point coordinates."""
-        return self.points['z']
+        return self.arr[2]
 
     @property
     def points(self):
@@ -153,7 +153,7 @@ class PointCloud(object):
         
         Returns
         -------
-        np.ndarray with shape (npoints, 3)
+        structured np.ndarray containing 'x', 'y' and 'z' point coordinates
     
         """
         return self.arr.T.ravel().view(
@@ -168,9 +168,10 @@ class PointCloud(object):
         namedtuple (minx, miny, minz, maxx, maxy, maxz)
         
         """
-        p = self.points
-        return Bounds(np.min(p['x']), np.min(p['y']), np.min(p['z']),
-                      np.max(p['x']), np.max(p['y']), np.max(p['z']))
+        x,y,z = self.arr
+        return Bounds(x.min(), y.min(), z.min(),
+                      x.max(), y.max(), z.max())
+
 
     @property
     def header(self):
@@ -220,7 +221,7 @@ class PointCloud(object):
         bounds = Bounds(minx, miny, minz, maxx, maxy, maxz)
         # Build results using generator to limit memory usage
         out_of_bounds = np.zeros(len(self))
-        for comparison in iter_out_of_bounds(self.points, bounds):
+        for comparison in iter_out_of_bounds(self, bounds):
             out_of_bounds = np.logical_or(comparison, out_of_bounds)
         
         # Deal with empty pointclouds
@@ -255,9 +256,7 @@ class PointCloud(object):
         """
         with File(fpath, mode='w', header=self.header,
                   vlrs=[VLR(**_VLR_DEFAULT)]) as f:
-            f.x = self.points['x']
-            f.y = self.points['y']
-            f.z = self.points['z']
+            f.x, f.y, f.z = self.arr
 
     def downsample(self, n):
         """Randomly sample the point cloud.
@@ -330,13 +329,12 @@ def _nones_to_infs(bounds):
         new.append(d)
     return Bounds(*new)
 
-def iter_out_of_bounds(points, bounds):
+def iter_out_of_bounds(pc, bounds):
     """Iteratively determine point coordinates outside of bounds.
 
     Arguments
     ---------
-    points: numpy.ndarray
-        structured array containing 'x', 'y' and 'z' point coordinates
+    pc: `PointCloud` instance
     bounds: `Bounds` namedtuple
         (minx, miny, minz, maxx, maxy, maxz) to test point coordinates against
     
@@ -361,8 +359,8 @@ def iter_out_of_bounds(points, bounds):
     
     for compare, c, bound in zip(comparison_funcs, coords, bounds):
         if bound is None: # None is a permissive bound
-            yield np.zeros_like(points[c], dtype=bool)
+            yield np.zeros_like(getattr(pc, c), dtype=bool)
         else:
-            yield compare(points[c], bound)
+            yield compare(getattr(pc, c), bound)
 
 

--- a/simulocloud/pointcloud.py
+++ b/simulocloud/pointcloud.py
@@ -232,7 +232,7 @@ class PointCloud(object):
                 raise EmptyPointCloud, "No points in crop bounds:\n{}".format(
                                             bounds)
          
-        return type(self)(self.points[~out_of_bounds])
+        return type(self)(self.arr[:, ~out_of_bounds])
 
     def to_txt(self, fpath):
         """Export point cloud coordinates as 3-column (xyz) ASCII file.

--- a/simulocloud/pointcloud.py
+++ b/simulocloud/pointcloud.py
@@ -33,7 +33,7 @@ class PointCloud(object):
     dtype = _DTYPE
 
     def __init__(self, xyz, header=None):
-        """Store 3D point coordinates in a structured array.
+        """Create PointCloud with 3D point coordinates stored in a (3*n) array.
         
         Arguments
         ---------
@@ -62,12 +62,12 @@ class PointCloud(object):
         """
         # Coerce None to empty array
         if xyz is None:
-            xyz = [[], [], []]
-
-        # Combine x, y and z into (flat) structured array 
-        self.points = np.column_stack(xyz).ravel().view(
-            dtype=[('x', self.dtype), ('y', self.dtype), ('z', self.dtype)])
+            x, y, z = [[], [], []]
         
+        # Store points as 3*n array
+        x, y, z = xyz # ensure only 3 coordinates
+        self.arr = np.stack([x, y, z])
+
         if header is not None:
             self._header = header
 
@@ -148,15 +148,16 @@ class PointCloud(object):
         return self.points['z']
 
     @property
-    def arr(self):
-        """Get point coordinates as unstructured n*3 array).
+    def points(self):
+        """Get point coordinates as a structured n*3 array).
         
         Returns
         -------
         np.ndarray with shape (npoints, 3)
     
         """
-        return self.points.view(self.dtype).reshape(-1, 3)
+        return self.arr.T.ravel().view(
+               dtype=[('x', self.dtype), ('y', self.dtype), ('z', self.dtype)])
 
     @property
     def bounds(self):

--- a/simulocloud/pointcloud.py
+++ b/simulocloud/pointcloud.py
@@ -73,7 +73,7 @@ class PointCloud(object):
 
     def __len__(self):
         """Number of points in point cloud"""
-        return len(self.arr)
+        return self.arr.shape[1]
 
     def __add__(self, other):
         """Concatenate two PointClouds."""

--- a/simulocloud/pointcloud.py
+++ b/simulocloud/pointcloud.py
@@ -62,7 +62,7 @@ class PointCloud(object):
         """
         # Coerce None to empty array
         if xyz is None:
-            x, y, z = [[], [], []]
+            xyz = [[], [], []]
         
         # Store points as 3*n array
         x, y, z = xyz # ensure only 3 coordinates

--- a/simulocloud/pointcloud.py
+++ b/simulocloud/pointcloud.py
@@ -273,7 +273,8 @@ class PointCloud(object):
         
         """
         n = min(n, len(self))
-        return type(self)(np.random.choice(self.points, n, replace=False))
+        idx = np.random.choice(len(self), n, replace=False)
+        return type(self)(self.arr[:, idx])
 
 # Container for bounds box surrounding PointCloud
 Bounds = namedtuple('Bounds', ['minx', 'miny', 'minz', 'maxx', 'maxy', 'maxz'])

--- a/simulocloud/visualise.py
+++ b/simulocloud/visualise.py
@@ -93,7 +93,7 @@ def _iter_scatter_args(pcs, dims, colours, labels):
         labels = _iteralphabet()
         
     for pc, colour, label in izip(pcs, colours, labels):
-        arrs = (pc.points[dim.lower()] for dim in dims) # extract coordinates
+        arrs = (getattr(pc, dim.lower()) for dim in dims) # extract coordinates
         kwargs = {'c': colour,
                   'label': label}
         yield arrs, kwargs

--- a/tests/test_pointcloud.py
+++ b/tests/test_pointcloud.py
@@ -22,7 +22,7 @@ def input_array():
 def expected_las_arr(fname='ALS.las'):
     """The array of points held in the example las data"""
     with File(abspath(fname)) as f:
-        return np.array([f.x, f.y, f.z]).T
+        return np.array([f.x, f.y, f.z])
 
 @pytest.fixture
 def pc_arr(input_array):
@@ -32,7 +32,7 @@ def pc_arr(input_array):
 @pytest.fixture
 def pc_arr_x10(pc_arr):
     """Multiply pc_arr values by 10."""
-    return PointCloud((pc_arr.arr*10).T)
+    return PointCloud((pc_arr.arr*10))
 
 @pytest.fixture
 def pc_las(fname='ALS.las'):
@@ -68,7 +68,7 @@ def get_fpaths(fdir):
 
 def test_PointCloud_read_from_array(pc_arr, input_array):
     """Can PointCloud initialise directly from a [xs, ys, zs] array?"""
-    assert np.allclose(pc_arr.arr, input_array.T)
+    assert np.allclose(pc_arr.arr, input_array)
 
 def test_PointCloud_read_from_single_las(pc_las, expected_las_arr):
     """Can PointCloud be constructed from a single .las file?"""
@@ -91,7 +91,7 @@ def test_empty_PointCloud():
 
 def test_arr_generation(pc_arr, input_array):
     """Does PointCloud.arr work as expected?."""
-    assert np.allclose(pc_arr.arr, input_array.T)
+    assert np.allclose(pc_arr.arr, input_array)
 
 def test_bounds_returns_accurate_boundary_box(pc_arr):
     """Does PointCloud.bounds accurately describe the bounding box?"""

--- a/tests/test_pointcloud.py
+++ b/tests/test_pointcloud.py
@@ -168,7 +168,7 @@ def test_PointCloud_exports_transparently_to_txt(pc_arr, tmpdir):
     fpath = tmpdir.join("_INPUT_DATA.txt").strpath
     pc_arr.to_txt(fpath) 
 
-    assert np.allclose(pc_arr.arr, PointCloud(np.loadtxt(fpath)).arr)
+    assert np.allclose(pc_arr.arr, PointCloud(np.loadtxt(fpath).T).arr)
 
 def test_PointCloud_exports_transparently_to_las(pc_las, tmpdir):
     """Are the points in the file output by PointCloud.to_las identical to input?"""


### PR DESCRIPTION
The storage of point coordinates as the structured array `points` is unwieldy and unnecessary. Primary storage has been changed to the simple, and publicly modifiable (3, n) array `arr`, with `points` implemented as a view on `arr`.

Any references to `points` will still work, but should be updated to `arr` instead. By contrast, existing references to the property `arr` will break, since it has changed shape from `(n, 3)` to `(3, n)`.